### PR TITLE
Small bug fix for active record validations and state query methods

### DIFF
--- a/lib/active_record/transitions.rb
+++ b/lib/active_record/transitions.rb
@@ -42,8 +42,15 @@ module ActiveRecord
     protected
 
     def write_state(state_machine, state)
+      ivar = state_machine.current_state_variable
+      prev_state = current_state(state_machine.name)
+      instance_variable_set(ivar, state)
       self.state = state.to_s
       save!
+    rescue ActiveRecord::RecordInvalid
+      self.state = prev_state.to_s
+      instance_variable_set(ivar, prev_state)
+      raise
     end
 
     def read_state(state_machine)


### PR DESCRIPTION
Commit message:

Allow state query methods to work in conditional validations

When you have a conditional validation, for example:

  validates(:name, :presence => true, :if => :red?)

Then `save!' should raise an exception if transitioning to`red' and
`name' isn't valid.

Adds a test and changes the `write_state' method for active record to
revert to previous state on a failed save.
