### PR TITLE
Fix to correct current_state attribute not returning the initial state on newly initialized objects. Close issue #9.

### DIFF
--- a/lib/active_record/transitions.rb
+++ b/lib/active_record/transitions.rb
@@ -54,7 +54,7 @@ module ActiveRecord
     end
 
     def read_state(state_machine)
-      self.state.to_sym
+      self.state && self.state.to_sym
     end
 
     def set_initial_state

--- a/test/test_active_record.rb
+++ b/test/test_active_record.rb
@@ -131,4 +131,17 @@ class TestActiveRecord < Test::Unit::TestCase
     @light.update_attribute(:state, 'green')
     assert @light.reload.green?, "reloaded state should come from database, not instance variable"
   end
+
+end
+
+class TestNewActiveRecord < TestActiveRecord
+
+  def setup
+    @light = TrafficLight.new
+  end
+
+  test "new active records defaults current state to the initial state" do
+    assert_equal :off, @light.current_state
+  end
+
 end


### PR DESCRIPTION
For newly initialized objects, the current_state attribute is not returning the initial state properly on HEAD.

This commit carries a simple fix to check in read_state that if an object's state field is nil, it returns nil and allows current_state to do its job, rather than blindly calling to_sym on the object's state field, which will cause an exception to be thrown in the case if the state field is nil.

Closes issue #9.
