### PR TITLE
Extend StandardError instead of the lower level Exception.

### DIFF
--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -27,7 +27,7 @@ require "transitions/state_transition"
 require "transitions/version"
 
 module Transitions
-  class InvalidTransition < Exception
+  class InvalidTransition < StandardError
 
   end
 


### PR DESCRIPTION
Typically StandardError represents application level exceptions.
