### PR TITLE
fixed setting initial state whenever :state isn't included in the query 

### DIFF
--- a/lib/active_record/transitions.rb
+++ b/lib/active_record/transitions.rb
@@ -58,7 +58,7 @@ module ActiveRecord
     end
 
     def set_initial_state
-      self.state ||= self.class.state_machine.initial_state.to_s
+      self.state ||= self.class.state_machine.initial_state.to_s if self.has_attribute?(:state)
     end
 
     def state_inclusion


### PR DESCRIPTION
While the querying will work, saving does not work without getting the :state attribute. For example,

g = Game.find(1, :select => [:id, :version])
=> #<Game id: 1, version: "1">

g.version = "sadf"
g.save
ActiveModel::MissingAttributeError: missing attribute: state

This is the expected behavior. You might want to add the same check (ie. self.has_attribute?(:state)) to validate, validates_presence_of and set_initial_state
