### PR TITLE
replaced class_eval with define_method in transitions#define_state_query_

### DIFF
--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -58,7 +58,7 @@ module Transitions
     def define_state_query_method(state_name)
       name = "#{state_name}?"
       undef_method(name) if method_defined?(name)
-      class_eval "def #{name}; current_state.to_s == %(#{state_name}) end"
+      define_method(name) { current_state.to_s == %(#{state_name}) }
     end
   end
 


### PR DESCRIPTION
replaced class_eval with define_method in transitions#define_state_query_method
