### PR TITLE
Autogenerate helper methods to check if transition can be performed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+* (bnmrrs) Add helper methods to check if a given transition is possible.
+
 # 1.0.0
 
 (troessner) Remove suppport for multipe state machines

--- a/README.rdoc
+++ b/README.rdoc
@@ -57,9 +57,10 @@ whereever you load your dependencies in your application.
 
 ==== Events
 
-When you declare an event, say <tt>discontinue</tt>, two methods are declared for
-you: <tt>discontinue</tt> and <tt>discontinue!</tt>. Both events will modify the <tt>state</tt> attribute on successful transition,
-but only the bang(!)-version will call <tt>save!</tt>.
+When you declare an event, say <tt>discontinue</tt>, three methods are declared for
+you: <tt>discontinue</tt>, <tt>discontinue!</tt> and <tt>can_discontinue?</tt>. The first two events will modify the <tt>state</tt> attribute on successful transition,
+but only the bang(!)-version will call <tt>save!</tt>.  The <tt>can_discontinue?</tt> method will
+not modify state but instead returns a boolean letting you know if a given transition is possible.
 
 ==== Automatic scope generation
 

--- a/lib/transitions/event.rb
+++ b/lib/transitions/event.rb
@@ -34,6 +34,10 @@ module Transitions
         machine.klass.send(:define_method, name.to_s) do |*args|
           machine.fire_event(name, self, false, *args)
         end
+
+        machine.klass.send(:define_method, "can_#{name.to_s}?") do |*args|
+          machine.events_for(current_state).include?(name.to_sym)
+        end
       end
       update(options, &block)
     end

--- a/test/event/test_event_checks.rb
+++ b/test/event/test_event_checks.rb
@@ -1,0 +1,34 @@
+require "helper"
+
+class ChecksTestSubject
+  include Transitions
+
+  state_machine :initial => :initial do
+    state :initial
+    state :opened
+    state :closed
+
+    event :open do
+      transitions :from => :initial, :to => :opened
+    end
+
+    event :close do
+      transitions :from => :opened, :to => :closed
+    end
+  end
+end
+
+class StateMachineChecksTest < Test::Unit::TestCase
+  test "checks if a given transition is possible" do
+    subject = ChecksTestSubject.new
+    assert_equal :initial, subject.current_state
+    assert_equal true, subject.can_open?
+    assert_equal false, subject.can_close?
+
+    subject.open
+
+    assert_equal false, subject.can_open?
+    assert_equal true, subject.can_close?
+  end
+end
+


### PR DESCRIPTION
Transitions now autogenerate a helper method to check if a transition can be performed.
