### PR TITLE
Problem with initial_state and mongoid

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -63,7 +63,7 @@ module ActiveModel
     end
 
     def set_initial_state
-      self.state ||= self.class.get_state_machine.initial_state.to_s if self.has_attribute?(:state)
+      self.state ||= self.class.get_state_machine.initial_state.to_s if self.respond_to?(:state=)
     end
 
     def state_inclusion


### PR DESCRIPTION
Using mongoid (v3.0.17) I have an issue with the initial state setting.

``` ruby
product = Product.new
product.current_state #=> :available
product.valid? #=> false
product.errors #=> ... {:state=>["can't be blank", "is not included in the list"]}
```

`ActiveModel#Transitions.set_initial_state` tests for `has_attribute?(:state)`.

``` ruby
self.state ||= self.class.get_state_machine.initial_state.to_s if self.has_attribute?(:state)
```

Mongoid returns `false` if the field is not set. Maybe it should only check `respond_to?(:state=)` don't you think ?
