### PR TITLE
Multiple success callbacks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -135,6 +135,12 @@ perfom some more complex success callbacks:
     transitions :to => :discontinued, :from => [:available, :out_of_stock]
   end
 
+If you need it, you can even call multiple methods or lambdas just passing an array:
+
+  event :discontinue, :success => [:notify_admin, lambda { |order| AdminNotifier.notify_about_discontinued_order(order) }] do
+    transitions :to => :discontinued, :from => [:available, :out_of_stock]
+  end
+
 ==== Timestamps
 
 If you'd like to note the time of a state change, Transitions comes with timestamps free!

--- a/lib/transitions/event.rb
+++ b/lib/transitions/event.rb
@@ -78,7 +78,7 @@ module Transitions
     end
 
     def update(options = {}, &block)
-      @success       = build_sucess_callback(options[:success]) if options.key?(:success)
+      @success       = build_success_callback(options[:success]) if options.key?(:success)
       self.timestamp = options[:timestamp] if options[:timestamp]
       instance_eval(&block) if block
       self
@@ -129,12 +129,18 @@ module Transitions
       end
     end
 
-    def build_sucess_callback(callback_symbol_or_proc)
-      case callback_symbol_or_proc
+    def build_success_callback(callback_names)
+      case callback_names
+      when Array
+        lambda do |record|
+          callback_names.each do |callback|
+            build_success_callback(callback).call(record)
+          end
+        end
       when Proc
-        callback_symbol_or_proc
+        callback_names
       when Symbol
-        lambda { |record| record.send(callback_symbol_or_proc) }
+        lambda { |record| record.send(callback_names) }
       end
     end
 


### PR DESCRIPTION
This allows a user to define a success callback with multiple callbacks.

``` ruby
event :reserve, success: [:set_reservation_date, lambda{|record| my_cool_thing(record)}] do                                                                                                                                      
  transitions to: :reserved                                                                                                            
end  
```

What do you think? I'll add an entry to the README if you want to merge it.
