### PR TITLE
Auto generated scopes use wrong state column

### DIFF
--- a/lib/transitions/machine.rb
+++ b/lib/transitions/machine.rb
@@ -102,7 +102,7 @@ module Transitions
         if @klass.respond_to?(state_name)
           raise InvalidMethodOverride, "Transitions: Can not define scope `#{state_name}` because there is already an equally named method defined - either rename the existing method or the state."
         end
-        @klass.scope state_name, @klass.where(:state => state_name)
+        @klass.scope state_name, @klass.where(@klass.state_machine.attribute_name => state_name)
       end
     end
   end


### PR DESCRIPTION
Hi,
i stumbled over this bug with auto scopes. The commit changes the generated scopes so the correct column name is read from the state machine.
