### PR TITLE
Use method_defined? for portability

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -26,7 +26,7 @@ module ActiveModel
 
     included do
       class ::Transitions::Machine
-        unless instance_methods.include?(:new_transitions_initialize) || instance_methods.include?(:new_transitions_update)
+        unless method_defined?(:new_transitions_initialize) || method_defined?(:new_transitions_update)
           attr_reader :attribute_name
           alias :old_transitions_initialize :initialize
           alias :old_transitions_update :update

--- a/lib/transitions/state.rb
+++ b/lib/transitions/state.rb
@@ -67,7 +67,7 @@ module Transitions
     private
     def define_state_query_method(machine)
       method_name, state_name = "#{@name}?", @name # Instance vars are out of scope when calling define_method below, so we use local variables.
-      if machine.klass.instance_methods.include?(method_name.to_sym)
+      if machine.klass.method_defined?(method_name.to_sym)
         raise InvalidMethodOverride, "Transitions: Can not define method `#{method_name}` because it is already defined - either rename the existing method or the state."
       end
       machine.klass.send :define_method, method_name do


### PR DESCRIPTION
Replace calls to instance_methods.include?(:symbol) with
method_defined?(:symbol) as this is more portable and prevents a Stack
Level Too Deep exception when running on Ruby 1.8 which returns an array
of String objects in instance_methods rather than symbols which Ruby 1.9
will return.
