### PR TITLE
ensure that enter is called for the initial state

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -88,6 +88,7 @@ module ActiveModel
 
     def set_initial_state
       self[transitions_state_column_name] ||= self.class.get_state_machine.initial_state.to_s if self.has_attribute?(transitions_state_column_name)
+      self.class.get_state_machine.state_index[self[transitions_state_column_name].to_sym].call_action(:enter, self)
     end
 
     def state_presence

--- a/test/active_record/test_active_record.rb
+++ b/test/active_record/test_active_record.rb
@@ -24,9 +24,10 @@ set_up_db CreateDifferentTrafficLights
 
 class TrafficLight < ActiveRecord::Base
   include ActiveModel::Transitions
+  attr_reader :power
 
   state_machine :auto_scopes => true do
-    state :off
+    state :off, enter: :turn_power_on
 
     state :red
     state :green
@@ -47,6 +48,11 @@ class TrafficLight < ActiveRecord::Base
     event :reset do
       transitions :to => :red, :from => [:off]
     end
+  end
+
+  def turn_power_on
+    raise "the power should not have been on already" if @power == :on
+    @power = :on
   end
 end
 
@@ -80,6 +86,11 @@ class TestActiveRecord < Test::Unit::TestCase
   test "states initial state" do
     assert @light.off?
     assert_equal :off, @light.current_state
+  end
+
+  test "calls enter when setting the initial state" do
+    @new_light = TrafficLight.new
+    assert_equal :on, @new_light.power
   end
 
   test "transition to a valid state" do


### PR DESCRIPTION
If `:enter` options were provided to the `initial_state` they would not get called on create. This seemed like the wrong behavior.

I wasn't familiar with the code at all, so I did my best to add it in a simple way =/
