### PR TITLE
add can_transition? and cant_transition? methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ the bang(!)-version will call `save!`.  The `can_discontinue?` method will not
 modify state but instead returns a boolean letting you know if a given
 transition is possible.
 
+In addition, a `can_transition?` method is added to the object that expects one or more event names as arguments. This semi-verbose method name is used to avoid collission with [https://github.com/ryanb/cancan](the authorization gem CanCan).
+
+    >> Product.new.can_transition? :out_of_stock
+    => true
+
 #### Automatic scope generation
 
 `transitions` will automatically generate scopes for you if you are using

--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -72,6 +72,16 @@ module Transitions
     instance_variable_set(ivar, new_state)
   end
 
+  def can_transition?(*events)
+    events.all? do |event|
+      self.class.get_state_machine.events_for(current_state).include?(event.to_sym)
+    end
+  end
+
+  def cant_transition?(*events)
+    !can_transition?(*events)
+  end
+
   def current_state
     sm   = self.class.get_state_machine
     ivar = sm.current_state_variable

--- a/test/machine/test_machine.rb
+++ b/test/machine/test_machine.rb
@@ -14,6 +14,10 @@ class MachineTestSubject
     event :timeout do
       transitions :from => :open, :to => :closed
     end
+
+    event :restart do
+      transitions :from => :closed, to: :open
+    end
   end
 end
 
@@ -30,6 +34,17 @@ class TransitionsMachineTest < Test::Unit::TestCase
     events = MachineTestSubject.get_state_machine.events_for(:open)
     assert events.include?(:shutdown)
     assert events.include?(:timeout)
+  end
+
+  test "knows that it can use a transition when it is available" do
+    machine = MachineTestSubject.new
+    machine.restart
+    assert machine.can_transition?(:shutdown)
+  end
+
+  test "knows that it can't use a transition when it is unavailable" do
+    machine = MachineTestSubject.new
+    assert machine.cant_transition?(:shutdown)
   end
 
   test "test fire_event" do


### PR DESCRIPTION
Added these to avoid having to interpolate strings to call the can_? methods.
