### PR TITLE
available_transitions method implemetation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ In addition, a `can_transition?` method is added to the object that expects one 
     >> Product.new.can_transition? :out_of_stock
     => true
 
+If you need to get all available transitions for current state you can simply call:
+
+    >> Product.new.available_transitions
+    => [:discontinued, :out_of_stock]
+    
 #### Automatic scope generation
 
 `transitions` will automatically generate scopes for you if you are using

--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -72,6 +72,10 @@ module Transitions
     instance_variable_set(ivar, new_state)
   end
 
+  def available_transitions
+    self.class.get_state_machine.events_for(current_state)
+  end
+
   def can_transition?(*events)
     events.all? do |event|
       self.class.get_state_machine.events_for(current_state).include?(event.to_sym)

--- a/test/machine/test_machine.rb
+++ b/test/machine/test_machine.rb
@@ -36,6 +36,13 @@ class TransitionsMachineTest < Test::Unit::TestCase
     assert events.include?(:timeout)
   end
 
+  test "knows all available transitions for current state" do
+    machine = MachineTestSubject.new
+    assert_equal [:restart], machine.available_transitions
+    machine.restart
+    assert_equal [:shutdown, :timeout], machine.available_transitions
+  end
+
   test "knows that it can use a transition when it is available" do
     machine = MachineTestSubject.new
     machine.restart


### PR DESCRIPTION
Method returns events that can be fired for an instance with the current state. It's a little bit simpler and clearer than calling `Model.get_state_machine.events_for(current_state)` somewhere in the application, I guess :)
