### PR TITLE
Ignore `set_initial_state` after state is persisted

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -50,10 +50,10 @@ module ActiveModel
       validate :state_presence
       validate :state_inclusion
     end
-    
+
     # The optional options argument is passed to find when reloading so you may
     # do e.g. record.reload(:lock => true) to reload the same record with an
-    # exclusive row lock. 
+    # exclusive row lock.
     def reload(options = nil)
       super.tap do
         sm = self.class.get_state_machine
@@ -75,7 +75,7 @@ module ActiveModel
       write_state_without_persistence(prev_state)
       raise
     end
-    
+
     def write_state_without_persistence(state)
       ivar = self.class.get_state_machine.current_state_variable
       instance_variable_set(ivar, state)
@@ -88,8 +88,8 @@ module ActiveModel
 
     def set_initial_state
       # In case we use a query with a custom select that excludes our state attribute name we need to skip the initialization below.
-      if self.has_attribute?(transitions_state_column_name)
-        self[transitions_state_column_name] ||= self.class.get_state_machine.initial_state.to_s
+      if self.has_attribute?(transitions_state_column_name) && state_not_set?
+        self[transitions_state_column_name] = self.class.get_state_machine.initial_state.to_s
         self.class.get_state_machine.state_index[self[transitions_state_column_name].to_sym].call_action(:enter, self)
       end
     end
@@ -104,6 +104,10 @@ module ActiveModel
       unless self.class.get_state_machine.states.map{|s| s.name.to_s }.include?(self[transitions_state_column_name].to_s)
         self.errors.add(transitions_state_column_name, :inclusion, :value => self[transitions_state_column_name])
       end
+    end
+
+    def state_not_set?
+      self[transitions_state_column_name].nil?
     end
   end
 end

--- a/test/active_record/test_active_record_scopes.rb
+++ b/test/active_record/test_active_record_scopes.rb
@@ -1,9 +1,9 @@
 require "helper"
 
-class CreateBears < ActiveRecord::Migration
+class CreateBunnies < ActiveRecord::Migration
   def self.up
-    create_table(:bears, :force => true) do |t|
-      t.string :state
+    create_table(:bunnies, :force => true) do |t|
+      t.string :status # Explicitly use another state column to ensure that this whole enchilada is working with other state column names than the default ones.
     end
   end
 end
@@ -15,16 +15,6 @@ class CreatePuppies < ActiveRecord::Migration
     end
   end
 end
-
-class CreateBunnies < ActiveRecord::Migration
-  def self.up
-    create_table(:bunnies, :force => true) do |t|
-      t.string :status # Explicitly use another state column to ensure that this whole enchilada is working with other state column names than the default ones.
-    end
-  end
-end
-
-set_up_db CreateBunnies, CreatePuppies
 
 class Bunny < ActiveRecord::Base
   include ActiveModel::Transitions
@@ -44,7 +34,7 @@ end
 
 class TestScopes < Test::Unit::TestCase
   def setup
-    set_up_db CreateBears, CreateBunnies, CreatePuppies
+    set_up_db CreateBunnies, CreatePuppies
     @bunny = Bunny.create!
   end
 

--- a/test/active_record/test_active_record_timestamps.rb
+++ b/test/active_record/test_active_record_timestamps.rb
@@ -13,8 +13,6 @@ class CreateOrders < ActiveRecord::Migration
   end
 end
 
-set_up_db CreateOrders
-
 class Order < ActiveRecord::Base
   include ActiveModel::Transitions
 

--- a/test/active_record/test_custom_select.rb
+++ b/test/active_record/test_custom_select.rb
@@ -1,18 +1,15 @@
 require "helper"
 
-# Regressiontest for https://github.com/troessner/transitions/issues/95
-# TODO We use this Trafficlight class quite a lot in our specs including a ton of duplication.
-#      Unify class and migration definition in one place and then clean up all related specs, including this one.
-class CreateTrafficLights < ActiveRecord::Migration
+# Regression test for https://github.com/troessner/transitions/issues/95
+class CreateSwitches < ActiveRecord::Migration
   def self.up
-    create_table(:traffic_lights, :force => true) do |t|
+    create_table(:switches, :force => true) do |t|
       t.string :state
-      t.string :name
     end
   end
 end
 
-class TrafficLight < ActiveRecord::Base
+class Switch < ActiveRecord::Base
   include ActiveModel::Transitions
 
   state_machine do
@@ -23,12 +20,12 @@ end
 
 class TestCustomSelect < Test::Unit::TestCase
   def setup
-    set_up_db CreateTrafficLights
-    @light = TrafficLight.create!
+    set_up_db CreateSwitches
+    Switch.create!
   end
 
   test "should not trigger an exception when we use a custom select query which excludes the name of our state attribute" do
-    result = TrafficLight.select("id, name")
+    result = Switch.select(:id)
     assert_nothing_raised NoMethodError do
       result.inspect
     end


### PR DESCRIPTION
The existing behavior will always invoke the :enter callback for the
record's current state, regardless of whether or not that state was 
previously set. 

This is particularly bad for persisted records, as loading the record 
from the database triggers the `set_initial_state` call, and will force 
the :enter callback to be repeated -- this behavior is problematic when
the callback is anything complex or non-idempotent, such as triggering 
an email. 

The solution introduced here is to avoid invoking the :enter callback 
unless `set_initial_state` actually assigns a new state.
