### PR TITLE
Refactoring.

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -1,25 +1,3 @@
-# Copyright (c) 2009 Rick Olson
-
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 module ActiveModel
   module Transitions
     extend ActiveSupport::Concern

--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -1,27 +1,6 @@
-# Copyright (c) 2009 Rick Olson
-
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 require "transitions/event"
 require "transitions/machine"
+require "transitions/presenter"
 require "transitions/state"
 require "transitions/state_transition"
 require "transitions/version"
@@ -29,6 +8,7 @@ require "transitions/version"
 module Transitions
   class InvalidTransition     < StandardError; end
   class InvalidMethodOverride < StandardError; end
+  include Presenter
 
   module ClassMethods
     def inherited(klass)

--- a/lib/transitions/event.rb
+++ b/lib/transitions/event.rb
@@ -1,25 +1,3 @@
-# Copyright (c) 2009 Rick Olson
-
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 module Transitions
   class Event
     attr_reader :name, :success, :timestamp

--- a/lib/transitions/presenter.rb
+++ b/lib/transitions/presenter.rb
@@ -1,0 +1,15 @@
+module Transitions
+  module Presenter
+    def available_states
+      @state_machine.states.map(&:name).sort_by {|x| x.to_s}
+    end
+
+    def available_events
+      @state_machine.events.keys.sort
+    end
+
+    def available_transitions
+      @state_machine.events_for(current_state)
+    end
+  end
+end

--- a/lib/transitions/state.rb
+++ b/lib/transitions/state.rb
@@ -1,25 +1,3 @@
-# Copyright (c) 2009 Rick Olson
-
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 module Transitions
   class State
     attr_reader :name, :options

--- a/lib/transitions/state_transition.rb
+++ b/lib/transitions/state_transition.rb
@@ -1,25 +1,3 @@
-# Copyright (c) 2009 Rick Olson
-
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 module Transitions
   class StateTransition
     attr_reader :from, :to, :options
@@ -31,17 +9,6 @@ module Transitions
 
     def executable?(obj, *args)
       [@guard].flatten.all? { |g| perform_guard(obj, g, *args) }
-    end
-
-    def perform_guard(obj, guard, *args)
-      case guard
-      when Symbol, String
-        obj.send(guard, *args)
-      when Proc
-        guard.call(obj, *args)
-      else
-        true
-      end
     end
 
     def execute(obj, *args)
@@ -68,6 +35,19 @@ module Transitions
 
     def from?(value)
       @from == value
+    end
+
+  private
+
+    def perform_guard(obj, guard, *args)
+      case guard
+      when Symbol, String
+        obj.send(guard, *args)
+      when Proc
+        guard.call(obj, *args)
+      else
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
- Remove useless copyright paragraphs which decreased readability
- Refactored Machine#fire_event big time
- Made StateTransition#perform_guard private
- Moved the Transitions#available\* methods out of the core module and
  into a separate Presenter module to make it clear that those methods
  are convenience methods
