### PR TITLE
Display warning if user supplies timestamps option

### DIFF
--- a/lib/transitions/machine.rb
+++ b/lib/transitions/machine.rb
@@ -88,6 +88,9 @@ module Transitions
     end
 
     def event(name, options = {}, &block)
+      if options.key?(:timestamps)
+        Rails.logger.info "WARNING: You specified an unknown option 'timestamps' for the event #{name.inspect}. Did you mean to say 'timestamp'?"
+      end
       (@events[name] ||= Event.new(self, name)).update(options, &block)
     end
 


### PR DESCRIPTION
I accidentally specified the option as `timestamps` rather than `timestamp`. I wished I had a warning, so I went ahead and added it here.
