### PR TITLE
Make current_state work with an empty string

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -61,7 +61,10 @@ module ActiveModel
     end
 
     def read_state
-      self[transitions_state_column_name] && self[transitions_state_column_name].to_sym
+      column_value = self[transitions_state_column_name]
+      result       = column_value && column_value.to_sym
+
+      result if self.class.available_states.include?(result)
     end
 
     def set_initial_state

--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -67,17 +67,20 @@ module Transitions
   end
 
   def current_state
-    sm   = self.class.get_state_machine
-    ivar = sm.current_state_variable
-
+    sm    = self.class.get_state_machine
+    ivar  = sm.current_state_variable
     value = instance_variable_get(ivar)
-    return value if value
 
     if ::Transitions.active_record_descendant?(self.class)
-      value = instance_variable_set(ivar, read_state)
+      value = read_state unless value.present?
     end
 
-    !(value.nil? || value.to_s.empty?) ? value : sm.initial_state
+    value = sm.initial_state unless value.present?
+
+    if ::Transitions.active_record_descendant?(self.class)
+      instance_variable_set(ivar, value)
+    end
+    value
   end
 
   def self.active_record_descendant?(klazz)

--- a/test/active_record/test_active_record.rb
+++ b/test/active_record/test_active_record.rb
@@ -71,6 +71,14 @@ class TestActiveRecord < Test::Unit::TestCase
     assert_equal "off", @light.state
   end
 
+  test 'record with an empty state column' do
+    @light.state = ''
+    @light.save(validate: false)
+
+    assert_equal :off, @light.current_state
+    assert_equal :off, @light.current_state
+  end
+
   test "new active records defaults current state to the initial state" do
     assert_equal :off, @light.current_state
   end


### PR DESCRIPTION
Not sure it is a responsibility of this gem. But maybe it will be useful.
I have an ActiveRecord model, let's say `Seller` with some exist records. I decided to add a state_machine and add a `status` column:

``` ruby
class Seller < ActiveRecord::Base
  include ActiveModel::Transitions

  state_machine attribute_name: :status, initial: :not_reviewed do
    state :not_reviewed
    state :verified

    event :verify do
      transitions to: :verified, from: [:not_reviewed]
    end
  end
end
```

I was surprised when I got:

``` ruby
seller = Seller.last # => { id: 1, status: '' }

# first time
seller.current_state # => :not_reviewed
# second time
seller.current_state # => :""
```

To fix it I'm suggesting to change `current_state` method.
