### PR TITLE
Fixes event_fired / event_failed only looking at public methods

### DIFF
--- a/lib/transitions/machine.rb
+++ b/lib/transitions/machine.rb
@@ -65,7 +65,7 @@ module Transitions
     end
 
     def handle_event_fired_calllback(record, new_state, event)
-      if record.respond_to?(:event_fired)
+      if record.respond_to?(:event_fired, true)
         record.send(:event_fired, record.current_state, new_state, event)
       end
     end
@@ -75,7 +75,9 @@ module Transitions
     end
 
     def handle_event_failed_callback(record, event)
-      record.send(:event_failed, event) if record.respond_to?(:event_failed)
+      if record.respond_to?(:event_failed, true)
+        record.send(:event_failed, event)
+      end
     end
 
     def state(name, options = {})


### PR DESCRIPTION
Sometimes it's more convenient to implement these methods as protected / private for records to hide them from the public API. Since we're using send we should be looking at protected / private methods as well.

On Ruby 2.x this is worse because responds_to? returns false for protected methods: http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html
