### PR TITLE
Allow passing non-Proc callables as guards

### DIFF
--- a/lib/transitions/state_transition.rb
+++ b/lib/transitions/state_transition.rb
@@ -40,11 +40,10 @@ module Transitions
   private
 
     def perform_guard(obj, guard, *args)
-      case guard
-      when Symbol, String
-        obj.send(guard, *args)
-      when Proc
+      if guard.respond_to?(:call)
         guard.call(obj, *args)
+      elsif guard.is_a?(Symbol) || guard.is_a?(String)
+        obj.send(guard, *args)
       else
         true
       end

--- a/test/state_transition/test_state_transition_guard_check.rb
+++ b/test/state_transition/test_state_transition_guard_check.rb
@@ -5,7 +5,7 @@ class TestStateTransitionGuardCheck < Test::Unit::TestCase
 
   test "should return true of there is no guard" do
     opts = {:from => "foo", :to => "bar"}
-      st = Transitions::StateTransition.new(opts)
+    st = Transitions::StateTransition.new(opts)
 
     assert st.executable?(nil, *args)
   end
@@ -32,6 +32,19 @@ class TestStateTransitionGuardCheck < Test::Unit::TestCase
 
   test "should call the proc passing the object if the guard is a proc" do
     opts = {:from => "foo", :to => "bar", :guard => Proc.new {|o, *args| o.test_guard(*args)}}
+    st = Transitions::StateTransition.new(opts)
+
+    obj = stub
+    obj.expects(:test_guard).with(*args)
+
+    st.executable?(obj, *args)
+  end
+
+  test "should call the callable passing the object if the guard responds to #call" do
+    callable = Object.new
+    callable.define_singleton_method(:call) { |obj, *args| obj.test_guard(*args) }
+
+    opts = {:from => "foo", :to => "bar", :guard => callable }
     st = Transitions::StateTransition.new(opts)
 
     obj = stub


### PR DESCRIPTION
This extends the existing Guard execution logic to allow anything that responds to `#call` as a valid Guard, instead of only Procs
