### PR TITLE
Don't use ActiveModel#has_attribute? due to Rails 4 bug

### DIFF
--- a/lib/active_model/transitions.rb
+++ b/lib/active_model/transitions.rb
@@ -66,7 +66,7 @@ module ActiveModel
 
     def set_initial_state
       # In case we use a query with a custom select that excludes our state attribute name we need to skip the initialization below.
-      if self.has_attribute?(transitions_state_column_name) && state_not_set?
+      if self.attribute_names.include?(transitions_state_column_name.to_s) && state_not_set?
         self[transitions_state_column_name] = self.class.get_state_machine.initial_state.to_s
         self.class.get_state_machine.state_index[self[transitions_state_column_name].to_sym].call_action(:enter, self)
       end


### PR DESCRIPTION
The end result is a confusing error: "ActiveModel::MissingAttributeError: missing attribute: state" due to the following bug in Rails 4:
 > Job.select("id").first.attribute_names
 => ["state", "id"]

In Rails 5:
 > Job.select("id").first.attribute_names
 => ["id"]

If code loops through model.attribute_names to display selected values, the error results:
 > job = Job.select("id").first; job.attribute_names.map{|n| job[n]}
ActiveModel::MissingAttributeError: missing attribute: state

With the current pull request:
 > job = Job.select("id").first; job.attribute_names.map{|n| job[n]}
 => [1]

The bug can be traced to a bug in Rails 4's has_attribute? method which adds the attribute name to the list even if it was not selected. To support this, since this is the current stable version, we can use attribute_names.include? instead of has_attribute?