### PR TITLE
Dry n fix presenter

### DIFF
--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -44,9 +44,12 @@ module Transitions
     base.extend(ClassMethods)
   end
 
+  def get_state_machine
+    self.class.get_state_machine
+  end
+
   def update_current_state(new_state, persist = false)
-    sm   = self.class.get_state_machine
-    ivar = sm.current_state_variable
+    ivar = get_state_machine.current_state_variable
 
     if Transitions.active_model_descendant?(self.class)
       write_state(new_state) if persist
@@ -58,7 +61,7 @@ module Transitions
   end
 
   def available_transitions
-    self.class.get_state_machine.events_for(current_state)
+    get_state_machine.events_for(current_state)
   end
 
   def can_transition?(*events)
@@ -72,7 +75,7 @@ module Transitions
   end
 
   def current_state
-    sm   = self.class.get_state_machine
+    sm   = get_state_machine
     ivar = sm.current_state_variable
 
     value = instance_variable_get(ivar)

--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -11,6 +11,8 @@ module Transitions
   include Presenter
 
   module ClassMethods
+    include Presenter
+
     def inherited(klass)
       super # Make sure we call other callbacks possibly defined upstream the ancestor chain.
       klass.state_machine = state_machine
@@ -29,14 +31,6 @@ module Transitions
     # rubocop:disable Style/AccessorMethodName
     def get_state_machine
       @state_machine
-    end
-
-    def available_states
-      @state_machine.states.map(&:name).sort_by(&:to_s)
-    end
-
-    def available_events
-      @state_machine.events.keys.sort
     end
   end
 

--- a/lib/transitions/presenter.rb
+++ b/lib/transitions/presenter.rb
@@ -1,15 +1,11 @@
 module Transitions
   module Presenter
     def available_states
-      @state_machine.states.map(&:name).sort_by(&:to_s)
+      get_state_machine.states.map(&:name).sort_by(&:to_s)
     end
 
     def available_events
-      @state_machine.events.keys.sort
-    end
-
-    def available_transitions
-      @state_machine.events_for(current_state)
+      get_state_machine.events.keys.sort
     end
   end
 end


### PR DESCRIPTION
Hi guys.
```ruby
o = Order.last
o.available_states #=> NoMethodError: undefined method `states' for nil:NilClass
```
That means `Transitions::Presenter` does not work. I think it would be much better if `o.available_states #(for an instance, not for a class)` show states what I actually can switch through events (need to discuss), but broken presenter is bad anyway :bomb: 

What do you think about it?