### PR TITLE
fix #168

### DIFF
--- a/lib/transitions/presenter.rb
+++ b/lib/transitions/presenter.rb
@@ -1,11 +1,11 @@
 module Transitions
   module Presenter
     def available_states
-      get_state_machine.states.map(&:name).sort_by(&:to_s)
+      get_state_machine.states.map(&:name)
     end
 
     def available_events
-      get_state_machine.events.keys.sort
+      get_state_machine.events.keys
     end
   end
 end

--- a/test/machine/test_available_states_listing.rb
+++ b/test/machine/test_available_states_listing.rb
@@ -16,7 +16,7 @@ end
 
 class TestAvailableStatesListing < Test::Unit::TestCase
   test 'available_states should return the states for the state machine' do
-    assert_equal [:drinking, :gambling, :smoking], Bender.available_states
+    assert_equal [:drinking, :smoking, :gambling], Bender.available_states
   end
   test 'available_events should return the events for the state machine' do
     assert_equal [:cough], Bender.available_events


### PR DESCRIPTION
`.available_states` lists the states in the same order they are defined