### PR TITLE
Minimal implementation of multiple timestamps

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -4,14 +4,10 @@ DuplicateMethodCall:
   - ActiveModel::Transitions#read_state
   - ActiveModel::Transitions#reload
   - ActiveModel::Transitions#set_initial_state
-  - ActiveModel::Transitions#set_initial_state
   - Transitions::Event#error_message_for_invalid_transitions
   - Transitions::Event#fire
-  - Transitions::Event#fire
-  - Transitions::Event#initialize
   - Transitions::Event#initialize
   - Transitions::Event#update
-  - Transitions::Machine#handle_event_success_callback
   - Transitions::Machine#handle_event_success_callback
   - Transitions::Machine#initial_state
   - Transitions::State#define_state_query_method
@@ -46,6 +42,19 @@ FeatureEnvy:
   - Transitions::Event#can_execute_transition_from_state?
   - Transitions::Event#default_timestamp_name
   - Transitions::Event#error_message_for_invalid_transitions
+InstanceVariableAssumption:
+  exclude:
+  - Transitions::Event
+  - Transitions::Machine
+  - Transitions::State
+ManualDispatch:
+  exclude:
+  - Transitions::Event#default_timestamp_name
+  - Transitions::Machine#fire_event
+  - Transitions::Machine#handle_event_failed_callback
+  - Transitions::Machine#handle_event_fired_callback
+  - Transitions::Machine#include_scopes
+  - Transitions::StateTransition#perform_guard
 NestedIterators:
   exclude:
   - Transitions::Event#build_success_callback
@@ -56,6 +65,7 @@ TooManyInstanceVariables:
   - Transitions::StateTransition
 TooManyStatements:
   exclude:
+  - initialize
   - Transitions::Event#build_success_callback
   - Transitions::Event#fire
   - Transitions::Machine#fire_event

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ corresponding discussion).
 If you'd like to note the time of a state change, Transitions comes with
 timestamps free! To activate them, simply pass the `timestamp` option to the
 event definition with a value of either true or the name of the timestamp
-column. *NOTE - This should be either true, a String or a Symbol*
+column. *NOTE - This should be either true, a String, a Symbol, or an Array of
+these*
 ```ruby
 # This will look for an attribute called exploded_at or exploded_on (in that order)
 # If present, it will be updated


### PR DESCRIPTION
In #173, I suggested accepting multiple timestamps for events.  This is an implementation that makes the least amount of code changes to implement this functionality.  It's also not a very pretty way to implement it.

If you trust the test suite, I can update the timestamp code more completely to handle this in a better way.

Let me know which you'd prefer.