### PR TITLE
ActiveModel::Dirty not used in Mongoid

### DIFF
--- a/lib/transitions.rb
+++ b/lib/transitions.rb
@@ -84,6 +84,6 @@ module Transitions
 
   def self.active_model_descendant?(klazz)
     # Checking directly for "ActiveModel" wouldn't work so we use some arbitrary module close to it.
-    defined?(ActiveModel) && klazz.included_modules.include?(ActiveModel::Dirty)
+    defined?(ActiveModel) && klazz.included_modules.include?(ActiveModel::Validations)
   end
 end


### PR DESCRIPTION
Mongoid doesn't make use of `ActiveModel::Dirty` a quick change to `ActiveModel::Validations` worked.