### PR TITLE
Remove explicit ActiveRecord dependency

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -50,6 +50,7 @@ InstanceVariableAssumption:
 ManualDispatch:
   exclude:
   - Transitions::Event#default_timestamp_name
+  - Transitions::Event#error_message_for_invalid_transitions
   - Transitions::Machine#fire_event
   - Transitions::Machine#handle_event_failed_callback
   - Transitions::Machine#handle_event_fired_callback

--- a/lib/transitions/event.rb
+++ b/lib/transitions/event.rb
@@ -142,7 +142,8 @@ module Transitions
     end
 
     def error_message_for_invalid_transitions(obj)
-      "Can't fire event `#{name}` in current state `#{obj.current_state}` for `#{obj.class.name}`"
+      "Can't fire event `#{name}` in current state `#{obj.current_state}` for `#{obj.class.name}`"\
+      " #{obj.respond_to?(:id) ? "with ID #{obj.id} " : nil}"
     end
   end
 end

--- a/lib/transitions/event.rb
+++ b/lib/transitions/event.rb
@@ -142,8 +142,7 @@ module Transitions
     end
 
     def error_message_for_invalid_transitions(obj)
-      "Can't fire event `#{name}` in current state `#{obj.current_state}` for `#{obj.class.name}`"\
-      " #{obj.class < ActiveRecord::Base && obj.persisted? ? "with ID #{obj.id} " : nil}"
+      "Can't fire event `#{name}` in current state `#{obj.current_state}` for `#{obj.class.name}`"
     end
   end
 end


### PR DESCRIPTION
The check for ActiveRecord::Base here was causing an exception in mongoid.  The tests don't cover that line and it may be better to just exclude it so that this is usable with other ORMs.